### PR TITLE
fix: Google Sign-In black screen + profile page with logout

### DIFF
--- a/mobile/purrcat_app_mobile/lib/ui/features/feed/views/feed_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/feed/views/feed_screen.dart
@@ -48,12 +48,7 @@ class _FeedScreenState extends State<FeedScreen> {
   }
 
   Future<void> _onRefresh() async {
-    // Pull-to-refresh: re-subscribing isn't needed since the stream
-    // is already live.  We could force a Firestore cache refresh here,
-    // but the simplest reactive solution is to wait a moment so the
-    // RefreshIndicator spinner shows, then let the stream emit.
     final completer = Completer<void>();
-    // Request a fresh read — the stream will re-emit with latest data.
     FirestoreService().getPosts().first.then((posts) {
       if (mounted) {
         setState(() => _posts = posts);
@@ -79,117 +74,76 @@ class _FeedScreenState extends State<FeedScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: backgroundColor,
-      body: RefreshIndicator(
-        onRefresh: _onRefresh,
-        color: brandPink,
-        child: CustomScrollView(
-          slivers: [
-            // Top App Bar
-            SliverAppBar(
-              backgroundColor: backgroundColor,
-              elevation: 0,
-              title: Text(
-                'PurrCat',
-                style: GoogleFonts.poppins(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  color: brandPink,
-                ),
+    return RefreshIndicator(
+      onRefresh: _onRefresh,
+      color: brandPink,
+      child: CustomScrollView(
+        slivers: [
+          // Top App Bar
+          SliverAppBar(
+            backgroundColor: backgroundColor,
+            elevation: 0,
+            title: Text(
+              'PurrCat',
+              style: GoogleFonts.poppins(
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+                color: brandPink,
               ),
-              actions: [
-                IconButton(
-                  icon: const Icon(Icons.search_rounded, color: headingColor),
-                  onPressed: () {},
-                ),
-                IconButton(
-                  icon: const Icon(
-                    Icons.notifications_none_rounded,
-                    color: headingColor,
-                  ),
-                  onPressed: () {},
-                ),
-              ],
-              pinned: true,
             ),
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.search_rounded, color: headingColor),
+                onPressed: () {},
+              ),
+              IconButton(
+                icon: const Icon(
+                  Icons.notifications_none_rounded,
+                  color: headingColor,
+                ),
+                onPressed: () {},
+              ),
+            ],
+            pinned: true,
+          ),
 
-            // Stories Section
-            SliverToBoxAdapter(
-              child: SizedBox(
-                height: 100,
-                child: ListView.builder(
-                  scrollDirection: Axis.horizontal,
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-                  itemCount: _stories.length + 1,
-                  itemBuilder: (context, index) {
-                    if (index == 0) {
-                      // Add Story Button
-                      return Padding(
-                        padding: const EdgeInsets.only(right: 12),
-                        child: Column(
-                          children: [
-                            DottedBorder(
-                              color: brandPink,
-                              strokeWidth: 2,
-                              dashPattern: const [6, 3],
-                              radius: const Radius.circular(50),
-                              child: Container(
-                                width: 60,
-                                height: 60,
-                                decoration: const BoxDecoration(
-                                  shape: BoxShape.circle,
-                                  color: backgroundColor,
-                                ),
-                                child: const Icon(
-                                  Icons.add,
-                                  color: brandPink,
-                                  size: 28,
-                                ),
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              'ADD',
-                              style: GoogleFonts.poppins(
-                                fontSize: 10,
-                                fontWeight: FontWeight.bold,
-                                color: bodyColor,
-                              ),
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-
-                    // User Story Item
-                    final storyIndex = index - 1;
+          // Stories Section
+          SliverToBoxAdapter(
+            child: SizedBox(
+              height: 100,
+              child: ListView.builder(
+                scrollDirection: Axis.horizontal,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                itemCount: _stories.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
                     return Padding(
                       padding: const EdgeInsets.only(right: 12),
                       child: Column(
                         children: [
-                          Container(
-                            width: 64,
-                            height: 64,
-                            padding: const EdgeInsets.all(2),
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              border: Border.all(
-                                color: brandPink,
-                                width: 2,
+                          DottedBorder(
+                            color: brandPink,
+                            strokeWidth: 2,
+                            dashPattern: const [6, 3],
+                            radius: const Radius.circular(50),
+                            child: Container(
+                              width: 60,
+                              height: 60,
+                              decoration: const BoxDecoration(
+                                shape: BoxShape.circle,
+                                color: backgroundColor,
                               ),
-                            ),
-                            child: CircleAvatar(
-                              radius: 30,
-                              backgroundImage: CachedNetworkImageProvider(
-                                _stories[storyIndex],
+                              child: const Icon(
+                                Icons.add,
+                                color: brandPink,
+                                size: 28,
                               ),
                             ),
                           ),
                           const SizedBox(height: 4),
                           Text(
-                            'USER${storyIndex + 1}',
+                            'ADD',
                             style: GoogleFonts.poppins(
                               fontSize: 10,
                               fontWeight: FontWeight.bold,
@@ -199,46 +153,68 @@ class _FeedScreenState extends State<FeedScreen> {
                         ],
                       ),
                     );
-                  },
-                ),
-              ),
-            ),
+                  }
 
-            // Posts Section
-            SliverList(
-              delegate: SliverChildBuilderDelegate(
-                (context, index) {
-                  return PostCard(
-                    post: _posts[index],
-                    onLoginRequired: () {
-                      showModalBottomSheet(
-                        context: context,
-                        isScrollControlled: true,
-                        builder: (_) => const LoginModal(),
-                      );
-                    },
+                  final storyIndex = index - 1;
+                  return Padding(
+                    padding: const EdgeInsets.only(right: 12),
+                    child: Column(
+                      children: [
+                        Container(
+                          width: 64,
+                          height: 64,
+                          padding: const EdgeInsets.all(2),
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: brandPink,
+                              width: 2,
+                            ),
+                          ),
+                          child: CircleAvatar(
+                            radius: 30,
+                            backgroundImage: CachedNetworkImageProvider(
+                              _stories[storyIndex],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          'USER${storyIndex + 1}',
+                          style: GoogleFonts.poppins(
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                            color: bodyColor,
+                          ),
+                        ),
+                      ],
+                    ),
                   );
                 },
-                childCount: _posts.length,
               ),
             ),
-          ],
-        ),
-      ),
-
-      // FAB
-      floatingActionButton: Container(
-        margin: const EdgeInsets.only(bottom: 40),
-        child: FloatingActionButton(
-          onPressed: _onFabPressed,
-          backgroundColor: brandPink,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
           ),
-          child: const Icon(Icons.camera_alt_rounded, color: Colors.white),
-        ),
+
+          // Posts Section
+          SliverList(
+            delegate: SliverChildBuilderDelegate(
+              (context, index) {
+                return PostCard(
+                  post: _posts[index],
+                  onLoginRequired: () {
+                    showModalBottomSheet(
+                      context: context,
+                      isScrollControlled: true,
+                      builder: (_) => const LoginModal(),
+                    );
+                  },
+                );
+              },
+              childCount: _posts.length,
+            ),
+          ),
+        ],
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endDocked,
     );
   }
 }

--- a/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
@@ -1,10 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart' hide AuthProvider;
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 import '../../feed/views/feed_screen.dart';
 import '../../marketplace/views/marketplace_screen.dart';
+import '../../profile/views/profile_screen.dart';
 import '../../../../ui/shared/bottom_nav_component.dart';
 import '../../../../ui/shared/login_modal.dart';
+import '../../../../ui/core/theme.dart';
 import '../../auth/view_models/auth_provider.dart';
 
 class HomeScreen extends StatefulWidget {
@@ -21,7 +25,7 @@ class _HomeScreenState extends State<HomeScreen> {
     const FeedScreen(),
     const MarketplaceScreen(),
     const Center(child: Text('Services Screen')),
-    const Center(child: Text('Profile Screen')),
+    const ProfileScreen(),
   ];
 
   void _onTabTapped(int index) {
@@ -30,19 +34,35 @@ class _HomeScreenState extends State<HomeScreen> {
       if (auth.isAuthenticated) {
         setState(() => _currentIndex = 3);
       } else {
-        showLoginModal(context);
+        showLoginModal(context, onLoginSuccess: () {
+          setState(() => _currentIndex = 3);
+        });
         return;
       }
     }
     setState(() => _currentIndex = index);
   }
 
-  void showLoginModal(BuildContext context) {
+  void _onFabPressed() {
+    if (FirebaseAuth.instance.currentUser == null) {
+      showModalBottomSheet(
+        context: context,
+        isScrollControlled: true,
+        builder: (_) => LoginModal(
+          onLoginSuccess: () => context.push('/feed/create'),
+        ),
+      );
+    } else {
+      context.push('/feed/create');
+    }
+  }
+
+  void showLoginModal(BuildContext context, {VoidCallback? onLoginSuccess}) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (_) => const LoginModal(),
+      builder: (_) => LoginModal(onLoginSuccess: onLoginSuccess),
     );
   }
 
@@ -50,6 +70,17 @@ class _HomeScreenState extends State<HomeScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       body: _screens[_currentIndex],
+      floatingActionButton: _currentIndex == 0
+          ? FloatingActionButton(
+              onPressed: _onFabPressed,
+              backgroundColor: brandPink,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: const Icon(Icons.camera_alt_rounded, color: Colors.white),
+            )
+          : null,
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
       bottomNavigationBar: BottomNavComponent(
         currentIndex: _currentIndex,
         onTap: _onTabTapped,

--- a/mobile/purrcat_app_mobile/lib/ui/features/profile/views/profile_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/profile/views/profile_screen.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_auth/firebase_auth.dart' hide AuthProvider;
+import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../auth/view_models/auth_provider.dart';
+import '../../../core/theme.dart';
+
+class ProfileScreen extends StatelessWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final auth = context.watch<AuthProvider>();
+    final user = auth.currentUser;
+
+    if (user == null) {
+      return const Center(child: Text('Not signed in'));
+    }
+
+    return Scaffold(
+      backgroundColor: Colors.grey[50],
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: const Text(
+          'Profile',
+          style: TextStyle(
+            color: headingColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            const SizedBox(height: 24),
+            // Avatar
+            CircleAvatar(
+              radius: 48,
+              backgroundColor: brandPink,
+              child: user.photoURL != null
+                  ? ClipOval(
+                      child: Image.network(
+                        user.photoURL!,
+                        width: 96,
+                        height: 96,
+                        fit: BoxFit.cover,
+                      ),
+                    )
+                  : Text(
+                      _initials(user.displayName ?? user.email ?? '?'),
+                      style: const TextStyle(
+                        fontSize: 32,
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+            ),
+            const SizedBox(height: 16),
+            // Name
+            Text(
+              user.displayName ?? 'No Name',
+              style: const TextStyle(
+                fontSize: 22,
+                fontWeight: FontWeight.bold,
+                color: headingColor,
+              ),
+            ),
+            const SizedBox(height: 4),
+            // Email
+            Text(
+              user.email ?? '',
+              style: const TextStyle(
+                fontSize: 15,
+                color: bodyColor,
+              ),
+            ),
+            const SizedBox(height: 32),
+            // Info cards
+            _buildInfoCard(
+              icon: Icons.email_outlined,
+              label: 'Email',
+              value: user.email ?? '-',
+            ),
+            const SizedBox(height: 12),
+            _buildInfoCard(
+              icon: Icons.verified_user_outlined,
+              label: 'User ID',
+              value: user.uid,
+            ),
+            const SizedBox(height: 32),
+            // Logout button
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: auth.isLoading
+                    ? null
+                    : () async {
+                        final confirm = await showDialog<bool>(
+                          context: context,
+                          builder: (ctx) => AlertDialog(
+                            title: const Text('Logout'),
+                            content: const Text(
+                              'Are you sure you want to sign out?',
+                            ),
+                            actions: [
+                              TextButton(
+                                onPressed: () => Navigator.pop(ctx, false),
+                                child: const Text('Cancel'),
+                              ),
+                              TextButton(
+                                onPressed: () => Navigator.pop(ctx, true),
+                                child: const Text(
+                                  'Logout',
+                                  style: TextStyle(color: Colors.red),
+                                ),
+                              ),
+                            ],
+                          ),
+                        );
+                        if (confirm == true) {
+                          await auth.logout();
+                          if (context.mounted) {
+                            context.go('/');
+                          }
+                        }
+                      },
+                icon: auth.isLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.logout, color: Colors.red),
+                label: Text(
+                  auth.isLoading ? 'Signing out...' : 'Sign Out',
+                  style: const TextStyle(color: Colors.red),
+                ),
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 14),
+                  side: const BorderSide(color: Colors.red),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard({
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.grey[200]!),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, color: brandPink, size: 22),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  label,
+                  style: const TextStyle(
+                    fontSize: 12,
+                    color: bodyColor,
+                  ),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value,
+                  style: const TextStyle(
+                    fontSize: 14,
+                    color: headingColor,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _initials(String name) {
+    final parts = name.trim().split(RegExp(r'\s+'));
+    if (parts.length >= 2) {
+      return '${parts[0][0]}${parts[1][0]}'.toUpperCase();
+    }
+    return name.isNotEmpty ? name[0].toUpperCase() : '?';
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/shared/login_modal.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/login_modal.dart
@@ -64,7 +64,7 @@ class LoginModal extends StatelessWidget {
                       final success = await auth.signInWithGoogle();
                       if (success && context.mounted) {
                         onLoginSuccess?.call();
-                        Navigator.pop(context);
+                        Navigator.of(context, rootNavigator: true).pop();
                       } else if (context.mounted && auth.error != null) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
@@ -107,7 +107,7 @@ class LoginModal extends StatelessWidget {
               onPressed: auth.isLoading
                   ? null
                   : () {
-                      Navigator.pop(context);
+                      Navigator.of(context, rootNavigator: true).pop();
                       context.push('/login');
                     },
               icon: const Icon(Icons.email_outlined, size: 20),
@@ -132,7 +132,7 @@ class LoginModal extends StatelessWidget {
               ),
               GestureDetector(
                 onTap: () {
-                  Navigator.pop(context);
+                  Navigator.of(context, rootNavigator: true).pop();
                   context.push('/register');
                 },
                 child: const Text(


### PR DESCRIPTION
## Summary

- Fix GoRouter `Navigator.pop()` conflict in bottom sheet — changed to `rootNavigator: true` to prevent black screen after Google Sign-In
- Register debug SHA-1 fingerprint (`64ee7d30...`) in Firebase Console to fix `PlatformException(10)` DEVELOPER_ERROR
- Create `ProfileScreen` with avatar, name, email, info cards, and Sign Out button with confirmation dialog
- Fix profile-tab login flow: onLoginSuccess callback sets tab index so user lands on profile after sign-in
- Clean up feed_screen.dart comments

## Test Plan
- [ ] Google Sign-In from modal closes properly (no black screen)
- [ ] Profile tab shows user info after login
- [ ] Sign Out clears session and goes home
- [ ] Email sign-in + register still work