### PR TITLE
fix(storage): init Firebase Storage + granular upload error handling

### DIFF
--- a/mobile/purrcat_app_mobile/firebase.json
+++ b/mobile/purrcat_app_mobile/firebase.json
@@ -4,5 +4,8 @@
     "location": "nam5",
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/mobile/purrcat_app_mobile/lib/data/services/firestore_service.dart
+++ b/mobile/purrcat_app_mobile/lib/data/services/firestore_service.dart
@@ -42,19 +42,27 @@ class FirestoreService {
     // Upload each image and collect download URLs.
     final List<String> imageUrls = [];
     for (int i = 0; i < images.length; i++) {
-      final ref = _storage.ref('posts/$postId/image_$i.jpg');
-      await ref.putFile(images[i]);
-      final url = await ref.getDownloadURL();
-      imageUrls.add(url);
+      try {
+        final ref = _storage.ref('posts/$postId/image_$i.jpg');
+        await ref.putFile(images[i]);
+        final url = await ref.getDownloadURL();
+        imageUrls.add(url);
+      } on FirebaseException catch (e) {
+        throw Exception('Storage upload failed [${e.code}]: ${e.message}');
+      }
     }
 
     // Write post document with the download URLs.
-    await docRef.set({
-      ...post.toFirestore(),
-      'id': postId,
-      'imageUrls': imageUrls,
-      'createdAt': FieldValue.serverTimestamp(),
-    });
+    try {
+      await docRef.set({
+        ...post.toFirestore(),
+        'id': postId,
+        'imageUrls': imageUrls,
+        'createdAt': FieldValue.serverTimestamp(),
+      });
+    } on FirebaseException catch (e) {
+      throw Exception('Firestore write failed [${e.code}]: ${e.message}');
+    }
   }
 
   // ── Real-time posts feed ────────────────────────────────────────────

--- a/mobile/purrcat_app_mobile/storage.rules
+++ b/mobile/purrcat_app_mobile/storage.rules
@@ -1,0 +1,8 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Initialize Firebase Storage bucket (wasn't set up — caused `storage/object-not-found` on post upload)
- Add `storage.rules` with auth-only access
- Register storage in `firebase.json`
- Add granular `FirebaseException` catch blocks to `createPost()` — now reports `[storage/xxx]` or `[firestore/xxx]` codes

Closes #30