### PR TITLE
fix: marketplace FAB + icon for adding product listings

### DIFF
--- a/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
@@ -81,11 +81,11 @@ class _HomeScreenState extends State<HomeScreen> {
       // Marketplace FAB — filter/settings
       return FloatingActionButton(
         onPressed: () {
-          // TODO: Open marketplace filters
+          // TODO: Navigate to add product listing
         },
         backgroundColor: brandPink,
         shape: const CircleBorder(),
-        child: const Icon(Icons.tune_rounded, color: Colors.white, size: 24),
+        child: const Icon(Icons.add, color: Colors.white, size: 28),
       );
     }
     return null;


### PR DESCRIPTION
Change marketplace FAB from tune/filter icon to + (add) icon for adding product listings.