### PR TITLE
feat: visible flag icon in feed interaction bar

### DIFF
--- a/mobile/purrcat_app_mobile/lib/ui/shared/post_card.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/post_card.dart
@@ -231,6 +231,19 @@ class _PostCardState extends State<PostCard> {
                   ),
                   onPressed: () {},
                 ),
+                // Report button
+                IconButton(
+                  icon: const Icon(
+                    Icons.flag_outlined,
+                    color: headingColor,
+                  ),
+                  onPressed: () => showReportModal(
+                    context,
+                    itemId: widget.post.id,
+                    itemType: 'feed',
+                    itemPreview: widget.post.content,
+                  ),
+                ),
                 const Spacer(),
                 // Bookmark button
                 IconButton(


### PR DESCRIPTION
Adds flag icon directly in the interaction bar (between comment and bookmark) for immediate visibility. Keeps the PopupMenuButton Report option.