### PR TITLE
fix: bottom nav icon above text

### DIFF
--- a/mobile/purrcat_app_mobile/lib/ui/shared/bottom_nav_component.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/bottom_nav_component.dart
@@ -49,31 +49,29 @@ class BottomNavComponent extends StatelessWidget {
       behavior: HitTestBehavior.opaque,
       child: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
         decoration: BoxDecoration(
           color: isActive ? brandPink.withOpacity(0.12) : Colors.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: Row(
+        child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
               icon,
-              size: 20,
+              size: 22,
               color: isActive ? brandPink : bodyColor,
             ),
-            if (isActive) ...[
-              const SizedBox(width: 6),
-              Text(
-                label,
-                style: TextStyle(
-                  fontSize: 11,
-                  fontWeight: FontWeight.w700,
-                  color: isActive ? brandPink : bodyColor,
-                  letterSpacing: 0.5,
-                ),
+            const SizedBox(height: 2),
+            Text(
+              label,
+              style: TextStyle(
+                fontSize: 10,
+                fontWeight: isActive ? FontWeight.w700 : FontWeight.w500,
+                color: isActive ? brandPink : bodyColor,
+                letterSpacing: 0.3,
               ),
-            ],
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
Changes bottom nav layout from Row (icon beside text) to Column (icon above text). Labels always visible.