### PR TITLE
feat: Services and Nearby Experts screen

### DIFF
--- a/mobile/purrcat_app_mobile/lib/data/models/services_model.dart
+++ b/mobile/purrcat_app_mobile/lib/data/models/services_model.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class Expert {
+  final String id;
+  final String name;
+  final String designation;
+  final String specialty;
+  final double rating;
+  final int reviewCount;
+  final int experienceYears;
+  final double distanceKm;
+  final String? profileImageUrl;
+  final List<String> availableSlots;
+
+  const Expert({
+    required this.id,
+    required this.name,
+    required this.designation,
+    required this.specialty,
+    required this.rating,
+    required this.reviewCount,
+    required this.experienceYears,
+    required this.distanceKm,
+    this.profileImageUrl,
+    required this.availableSlots,
+  });
+}
+
+class ServiceCategory {
+  final String id;
+  final String label;
+  final String subLabel;
+  final IconData icon;
+  final Color bgColor;
+
+  const ServiceCategory({
+    required this.id,
+    required this.label,
+    required this.subLabel,
+    required this.icon,
+    required this.bgColor,
+  });
+}

--- a/mobile/purrcat_app_mobile/lib/data/services/mock_services_data.dart
+++ b/mobile/purrcat_app_mobile/lib/data/services/mock_services_data.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import '../../../data/models/services_model.dart';
+
+const List<ServiceCategory> serviceCategories = [
+  ServiceCategory(
+    id: 'vaccinations',
+    label: 'Vaccinations',
+    subLabel: '12 Vets available',
+    icon: Icons.vaccines,
+    bgColor: Color(0xFFFCE4EC),
+  ),
+  ServiceCategory(
+    id: 'grooming',
+    label: 'Grooming',
+    subLabel: '8 Groomers nearby',
+    icon: Icons.shower,
+    bgColor: Color(0xFFE3F2FD),
+  ),
+];
+
+const List<Expert> mockExperts = [
+  Expert(
+    id: 'expert-1',
+    name: 'Dr. Sarah Chen',
+    designation: 'Senior Veterinarian',
+    specialty: 'Feline Internal Medicine',
+    rating: 4.9,
+    reviewCount: 128,
+    experienceYears: 12,
+    distanceKm: 1.2,
+    profileImageUrl:
+        'https://images.unsplash.com/photo-1559839734-2b71ea197ec2?w=200&h=200&fit=crop&crop=face',
+    availableSlots: ['09:00 AM', '10:30 AM', '11:00 AM', '02:00 PM'],
+  ),
+  Expert(
+    id: 'expert-2',
+    name: 'Dr. Marcus Rivera',
+    designation: 'Veterinary Surgeon',
+    specialty: 'Cat Orthopedics',
+    rating: 4.7,
+    reviewCount: 94,
+    experienceYears: 8,
+    distanceKm: 2.5,
+    profileImageUrl:
+        'https://images.unsplash.com/photo-1622253692010-333f2da6031d?w=200&h=200&fit=crop&crop=face',
+    availableSlots: ['09:00 AM', '10:00 AM', '11:30 AM', '03:00 PM'],
+  ),
+  Expert(
+    id: 'expert-3',
+    name: 'Lisa Nakamura',
+    designation: 'Professional Cat Groomer',
+    specialty: 'Persian & Longhair Breeds',
+    rating: 4.8,
+    reviewCount: 203,
+    experienceYears: 6,
+    distanceKm: 0.8,
+    profileImageUrl:
+        'https://images.unsplash.com/photo-1594744803329-e58b31de8bf5?w=200&h=200&fit=crop&crop=face',
+    availableSlots: ['08:30 AM', '10:00 AM', '01:00 PM', '04:00 PM'],
+  ),
+  Expert(
+    id: 'expert-4',
+    name: 'Dr. Emily Watson',
+    designation: 'Dermatology Specialist',
+    specialty: 'Cat Skin & Allergy Care',
+    rating: 4.9,
+    reviewCount: 76,
+    experienceYears: 10,
+    distanceKm: 3.1,
+    profileImageUrl:
+        'https://images.unsplash.com/photo-1594824476967-48c8b964273f?w=200&h=200&fit=crop&crop=face',
+    availableSlots: ['09:30 AM', '11:00 AM', '02:30 PM', '05:00 PM'],
+  ),
+  Expert(
+    id: 'expert-5',
+    name: 'James Okafor',
+    designation: 'Certified Feline Behaviorist',
+    specialty: 'Anxiety & Behavioral Therapy',
+    rating: 4.6,
+    reviewCount: 158,
+    experienceYears: 7,
+    distanceKm: 1.9,
+    profileImageUrl:
+        'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=200&h=200&fit=crop&crop=face',
+    availableSlots: ['08:00 AM', '10:00 AM', '01:30 PM', '03:30 PM'],
+  ),
+];

--- a/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/home/views/home_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 import '../../feed/views/feed_screen.dart';
 import '../../marketplace/views/marketplace_screen.dart';
 import '../../profile/views/profile_screen.dart';
+import '../../services/views/services_screen.dart';
 import '../../../../ui/shared/bottom_nav_component.dart';
 import '../../../../ui/shared/login_modal.dart';
 import '../../../../ui/core/theme.dart';
@@ -24,7 +25,7 @@ class _HomeScreenState extends State<HomeScreen> {
   final List<Widget> _screens = [
     const FeedScreen(),
     const MarketplaceScreen(),
-    const Center(child: Text('Services Screen')),
+    const ServicesScreen(),
     const ProfileScreen(),
   ];
 

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/views/services_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/views/services_screen.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../../../../ui/core/theme.dart';
+import '../widgets/map_layer.dart';
+import '../widgets/services_header.dart';
+import '../widgets/category_list.dart';
+import '../widgets/expert_list.dart';
+
+class ServicesScreen extends StatelessWidget {
+  const ServicesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: scaffoldBg,
+      body: Stack(
+        children: [
+          // ── Map Background (full height) ──
+          const Positioned.fill(child: MapLayer()),
+
+          // ── Draggable Bottom Sheet ──
+          DraggableScrollableSheet(
+            initialChildSize: 0.6,
+            minChildSize: 0.3,
+            maxChildSize: 0.92,
+            builder: (context, scrollController) {
+              return Container(
+                decoration: const BoxDecoration(
+                  color: scaffoldBg,
+                  borderRadius: BorderRadius.only(
+                    topLeft: Radius.circular(24),
+                    topRight: Radius.circular(24),
+                  ),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black12,
+                      blurRadius: 20,
+                      offset: Offset(0, -4),
+                    ),
+                  ],
+                ),
+                child: Column(
+                  children: [
+                    // ── Drag Handle ──
+                    const SizedBox(height: 8),
+                    Container(
+                      width: 40,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade300,
+                        borderRadius: BorderRadius.circular(2),
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+
+                    // ── Scrollable Content ──
+                    Expanded(
+                      child: ListView(
+                        controller: scrollController,
+                        padding: const EdgeInsets.only(bottom: 100),
+                        children: const [
+                          ServicesHeader(),
+                          SizedBox(height: 12),
+                          CategoryList(),
+                          SizedBox(height: 16),
+                          ExpertList(),
+                          SizedBox(height: 24),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/category_list.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/category_list.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../../../../ui/core/theme.dart';
+import '../../../../data/models/services_model.dart';
+import '../../../../data/services/mock_services_data.dart';
+
+class CategoryList extends StatelessWidget {
+  const CategoryList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 160,
+      child: ListView.separated(
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        scrollDirection: Axis.horizontal,
+        itemCount: serviceCategories.length,
+        separatorBuilder: (_, __) => const SizedBox(width: 14),
+        itemBuilder: (context, index) {
+          final cat = serviceCategories[index];
+          return _CategoryCard(category: cat);
+        },
+      ),
+    );
+  }
+}
+
+class _CategoryCard extends StatelessWidget {
+  final ServiceCategory category;
+
+  const _CategoryCard({required this.category});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => HapticFeedback.lightImpact(),
+      child: Container(
+        width: 170,
+        decoration: BoxDecoration(
+          color: category.bgColor,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          children: [
+            // Icon top-left
+            Positioned(
+              left: 14,
+              top: 14,
+              child: Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.7),
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(
+                  category.icon,
+                  color: brandPink,
+                  size: 22,
+                ),
+              ),
+            ),
+
+            // Text bottom-left
+            Positioned(
+              left: 14,
+              bottom: 30,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    category.label,
+                    style: GoogleFonts.inter(
+                      fontSize: 15,
+                      fontWeight: FontWeight.w700,
+                      color: headingColor,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    category.subLabel,
+                    style: GoogleFonts.inter(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w500,
+                      color: bodyColor,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+
+            // Paw-print watermark bottom-right
+            Positioned(
+              right: -10,
+              bottom: -10,
+              child: Opacity(
+                opacity: 0.08,
+                child: Icon(
+                  Icons.pets,
+                  size: 80,
+                  color: headingColor,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_card.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_card.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:shimmer/shimmer.dart' show Shimmer;
+import '../../../../ui/core/theme.dart';
+import '../../../../data/models/services_model.dart';
+
+class ExpertCard extends StatefulWidget {
+  final Expert expert;
+
+  const ExpertCard({super.key, required this.expert});
+
+  @override
+  State<ExpertCard> createState() => _ExpertCardState();
+}
+
+class _ExpertCardState extends State<ExpertCard> {
+  String? _selectedSlot;
+
+  @override
+  Widget build(BuildContext context) {
+    final expert = widget.expert;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 20, vertical: 6),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.04),
+            blurRadius: 10,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // ── Profile Image ──
+              ClipRRect(
+                borderRadius: BorderRadius.circular(15),
+                child: expert.profileImageUrl != null
+                    ? CachedNetworkImage(
+                        imageUrl: expert.profileImageUrl!,
+                        width: 56,
+                        height: 56,
+                        fit: BoxFit.cover,
+                        errorWidget: (_, __, ___) => _fallbackAvatar(),
+                        placeholder: (_, __) => Shimmer.fromColors(
+                          baseColor: Colors.grey.shade200,
+                          highlightColor: Colors.grey.shade100,
+                          child: Container(
+                            width: 56,
+                            height: 56,
+                            color: Colors.white,
+                          ),
+                        ),
+                      )
+                    : _fallbackAvatar(),
+              ),
+              const SizedBox(width: 12),
+
+              // ── Info Section ──
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Name + Distance
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            expert.name,
+                            style: GoogleFonts.inter(
+                              fontSize: 15,
+                              fontWeight: FontWeight.w700,
+                              color: headingColor,
+                            ),
+                          ),
+                        ),
+                        // Distance badge
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: const Color(0xFFF5F5F5),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Text(
+                            '${expert.distanceKm} KM',
+                            style: GoogleFonts.inter(
+                              fontSize: 11,
+                              fontWeight: FontWeight.w600,
+                              color: bodyColor,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 3),
+                    // Star Rating + Reviews
+                    Row(
+                      children: [
+                        const Icon(
+                          Icons.star,
+                          color: Color(0xFFFFB800),
+                          size: 16,
+                        ),
+                        const SizedBox(width: 3),
+                        Text(
+                          '${expert.rating}',
+                          style: GoogleFonts.inter(
+                            fontSize: 13,
+                            fontWeight: FontWeight.w600,
+                            color: headingColor,
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        Text(
+                          '(${expert.reviewCount} reviews)',
+                          style: GoogleFonts.inter(
+                            fontSize: 12,
+                            color: bodyColor,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 3),
+                    // Designation + YoE
+                    Text(
+                      expert.designation,
+                      style: GoogleFonts.inter(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                        color: bodyColor,
+                      ),
+                    ),
+                    Text(
+                      '${expert.specialty} · ${expert.experienceYears} yr exp',
+                      style: GoogleFonts.inter(
+                        fontSize: 11,
+                        color: bodyColor,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 12),
+
+          // ── AVAILABLE TODAY + Time Slots ──
+          Text(
+            'AVAILABLE TODAY',
+            style: GoogleFonts.inter(
+              fontSize: 10,
+              fontWeight: FontWeight.w700,
+              color: brandPink,
+              letterSpacing: 0.8,
+            ),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 36,
+            child: ListView.separated(
+              scrollDirection: Axis.horizontal,
+              itemCount: expert.availableSlots.length,
+              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              itemBuilder: (context, index) {
+                final slot = expert.availableSlots[index];
+                final isSelected = _selectedSlot == slot;
+                return GestureDetector(
+                  onTap: () {
+                    HapticFeedback.selectionClick();
+                    setState(() => _selectedSlot = slot);
+                  },
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 8,
+                    ),
+                    decoration: BoxDecoration(
+                      color: isSelected ? brandPink : const Color(0xFFF5F5F5),
+                      borderRadius: BorderRadius.circular(20),
+                      border: isSelected
+                          ? null
+                          : Border.all(
+                              color: const Color(0xFFE0E0E0),
+                              width: 1,
+                            ),
+                    ),
+                    child: Text(
+                      slot,
+                      style: GoogleFonts.inter(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w600,
+                        color: isSelected ? Colors.white : headingColor,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _fallbackAvatar() {
+    return Container(
+      width: 56,
+      height: 56,
+      decoration: BoxDecoration(
+        color: brandPink.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(15),
+      ),
+      child: const Icon(Icons.person, color: brandPink, size: 28),
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_list.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_list.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import '../../../../data/models/services_model.dart';
+import '../../../../data/services/mock_services_data.dart';
+import 'expert_card.dart';
+
+class ExpertList extends StatelessWidget {
+  const ExpertList({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: mockExperts
+          .map((expert) => ExpertCard(expert: expert))
+          .toList(),
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/map_layer.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/map_layer.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../../ui/core/theme.dart';
+
+class MapLayer extends StatelessWidget {
+  const MapLayer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        // ── Placeholder Map ──
+        Container(
+          color: const Color(0xFFE8F0FE),
+          child: const Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(Icons.map_outlined, size: 48, color: Color(0xFFB0BEC5)),
+                SizedBox(height: 8),
+                Text(
+                  'Map View\n(Google Maps / Mapbox)',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Color(0xFF90A4AE),
+                    fontSize: 14,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+
+        // ── Custom Marker: Paws Clinic ──
+        Positioned(
+          left: 60,
+          top: 40,
+          child: _CustomMarker(
+            label: 'PAWS',
+            subLabel: 'CLINIC',
+            icon: Icons.medical_services,
+            color: const Color(0xFF8B1A4A), // Dark Pink/Maroon
+          ),
+        ),
+
+        // ── Custom Marker: Fluff & Buff ──
+        Positioned(
+          right: 100,
+          bottom: 80,
+          child: _CustomMarker(
+            label: 'FLUFF',
+            subLabel: '& BUFF',
+            icon: Icons.content_cut,
+            color: brandPink,
+          ),
+        ),
+
+        // ── My Location FAB ──
+        Positioned(
+          right: 16,
+          bottom: 16,
+          child: GestureDetector(
+            onTap: () {
+              HapticFeedback.lightImpact();
+            },
+            child: Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.15),
+                    blurRadius: 6,
+                    offset: const Offset(0, 2),
+                  ),
+                ],
+              ),
+              child: const Icon(
+                Icons.my_location,
+                color: brandPink,
+                size: 20,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CustomMarker extends StatelessWidget {
+  final String label;
+  final String subLabel;
+  final IconData icon;
+  final Color color;
+
+  const _CustomMarker({
+    required this.label,
+    required this.subLabel,
+    required this.icon,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // Pin icon
+        Container(
+          width: 44,
+          height: 44,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: 2),
+            boxShadow: [
+              BoxShadow(
+                color: color.withOpacity(0.4),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
+          ),
+          child: Icon(icon, color: Colors.white, size: 22),
+        ),
+        const SizedBox(height: 4),
+        // Label
+        Column(
+          children: [
+            Text(
+              label,
+              style: const TextStyle(
+                fontSize: 10,
+                fontWeight: FontWeight.w700,
+                color: Colors.black87,
+                letterSpacing: 0.5,
+              ),
+            ),
+            Text(
+              subLabel,
+              style: const TextStyle(
+                fontSize: 9,
+                fontWeight: FontWeight.w600,
+                color: Colors.black87,
+                letterSpacing: 0.3,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/services_header.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/services_header.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import '../../../../ui/core/theme.dart';
+
+class ServicesHeader extends StatelessWidget {
+  const ServicesHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // ── Sub-header + View All ──
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'NEARBY EXPERTS',
+                style: GoogleFonts.inter(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w700,
+                  color: const Color(0xFF8B1A4A),
+                  letterSpacing: 1.2,
+                ),
+              ),
+              GestureDetector(
+                onTap: () {},
+                child: Text(
+                  'View All',
+                  style: GoogleFonts.inter(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: brandPink,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          // ── Main Title ──
+          Text(
+            'Premium Services',
+            style: GoogleFonts.inter(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              color: headingColor,
+              height: 1.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Build Services and Nearby Experts screen with split-view map + draggable sheet.

- Map placeholder with custom markers (PAWS CLINIC, FLUFF and BUFF) + location FAB
- DraggableScrollableSheet covering 60% with drag handle
- NEARBY EXPERTS header + "Premium Services" title + View All link
- Horizontal category cards: Vaccinations (12 vets) + Grooming (8 groomers)
- ExpertCard: profile image, name, rating, designation, experience, distance badge
- AVAILABLE TODAY time slots with haptic feedback + animated selection
- 5 mock experts (3 veterinarians, 1 groomer, 1 feline behaviorist)
- Brand pink #F07E96, Inter font, consistent with existing Purrfect screens

Closes #44