### PR TITLE
feat: Live OSM Map with GPS Location & Nearby Services

### DIFF
--- a/mobile/purrcat_app_mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/purrcat_app_mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <!-- Location permissions for geolocator -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <!-- Required for OSM tile downloads -->
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <application
         android:label="purrcat_app_mobile"
         android:name="${applicationName}"

--- a/mobile/purrcat_app_mobile/ios/Runner/Info.plist
+++ b/mobile/purrcat_app_mobile/ios/Runner/Info.plist
@@ -66,5 +66,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<!-- Location permissions required by geolocator -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Purrfect needs your location to show nearby vets and groomers.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>Purrfect needs your location to show nearby vets and groomers.</string>
 </dict>
 </plist>

--- a/mobile/purrcat_app_mobile/lib/data/models/nearby_service_model.dart
+++ b/mobile/purrcat_app_mobile/lib/data/models/nearby_service_model.dart
@@ -1,0 +1,34 @@
+import 'package:latlong2/latlong.dart';
+
+/// Type of nearby pet service provider.
+enum ServiceType { vet, groomer }
+
+/// Represents a single pet service location on the map.
+class NearbyService {
+  final String id;
+  final String name;
+  final String address;
+  final ServiceType type;
+  final double rating;
+  final int reviewCount;
+  final double distanceKm;
+  final LatLng position;
+  final String? phone;
+  final List<String> availableSlots;
+
+  const NearbyService({
+    required this.id,
+    required this.name,
+    required this.address,
+    required this.type,
+    required this.rating,
+    required this.reviewCount,
+    required this.distanceKm,
+    required this.position,
+    this.phone,
+    required this.availableSlots,
+  });
+
+  /// Human-readable type label.
+  String get typeLabel => type == ServiceType.vet ? 'Veterinary Clinic' : 'Pet Groomer';
+}

--- a/mobile/purrcat_app_mobile/lib/data/repositories/nearby_services_repository.dart
+++ b/mobile/purrcat_app_mobile/lib/data/repositories/nearby_services_repository.dart
@@ -1,0 +1,147 @@
+import 'dart:math';
+
+import 'package:latlong2/latlong.dart';
+
+import '../models/nearby_service_model.dart';
+
+/// Simulates GET /v1/services/nearby?lat={lat}&long={lng}
+///
+/// In production, replace the body of [fetchNearbyServices] with a
+/// real HTTP call using Dio or http package.
+class NearbyServicesRepository {
+  static final NearbyServicesRepository _instance =
+      NearbyServicesRepository._internal();
+  factory NearbyServicesRepository() => _instance;
+  NearbyServicesRepository._internal();
+
+  /// Generates mock services within ~5 km of [userLat],[userLng].
+  Future<List<NearbyService>> fetchNearbyServices({
+    required double userLat,
+    required double userLng,
+  }) async {
+    // Simulate network delay
+    await Future.delayed(const Duration(milliseconds: 900));
+
+    final rng = Random(42); // deterministic seed for consistent mock data
+
+    final mockData = <Map<String, dynamic>>[
+      {
+        'name': 'Paws Clinic',
+        'address': 'Jl. Sudirman No.12, Jakarta',
+        'type': ServiceType.vet,
+        'rating': 4.9,
+        'reviews': 124,
+        'dLat': 0.012,
+        'dLng': -0.018,
+        'phone': '+62 21 555-0101',
+        'slots': ['09:00', '10:30', '14:00', '16:00'],
+      },
+      {
+        'name': 'MeowWell Animal Hospital',
+        'address': 'Jl. Thamrin No.5, Jakarta',
+        'type': ServiceType.vet,
+        'rating': 4.7,
+        'reviews': 89,
+        'dLat': -0.021,
+        'dLng': 0.009,
+        'phone': '+62 21 555-0202',
+        'slots': ['08:30', '11:00', '13:30'],
+      },
+      {
+        'name': 'Fluff & Buff Grooming',
+        'address': 'Jl. Gatot Subroto No.3, Jakarta',
+        'type': ServiceType.groomer,
+        'rating': 4.8,
+        'reviews': 211,
+        'dLat': 0.031,
+        'dLng': 0.024,
+        'phone': '+62 21 555-0303',
+        'slots': ['10:00', '12:00', '15:00', '17:30'],
+      },
+      {
+        'name': 'Kitty Spa & Groom',
+        'address': 'Jl. Kebon Jeruk No.8, Jakarta',
+        'type': ServiceType.groomer,
+        'rating': 4.5,
+        'reviews': 67,
+        'dLat': -0.038,
+        'dLng': -0.012,
+        'phone': '+62 21 555-0404',
+        'slots': ['09:30', '11:30', '14:30'],
+      },
+      {
+        'name': 'CatCare Veterinary',
+        'address': 'Jl. Kuningan No.17, Jakarta',
+        'type': ServiceType.vet,
+        'rating': 4.6,
+        'reviews': 52,
+        'dLat': 0.025,
+        'dLng': -0.033,
+        'phone': '+62 21 555-0505',
+        'slots': ['08:00', '10:00', '13:00', '15:30'],
+      },
+      {
+        'name': 'PurrFect Grooming Salon',
+        'address': 'Jl. MT Haryono No.2, Jakarta',
+        'type': ServiceType.groomer,
+        'rating': 4.9,
+        'reviews': 178,
+        'dLat': -0.014,
+        'dLng': 0.041,
+        'phone': '+62 21 555-0606',
+        'slots': ['10:30', '13:00', '16:30'],
+      },
+      {
+        'name': 'Dr. Whiskers Animal Clinic',
+        'address': 'Jl. Casablanca No.9, Jakarta',
+        'type': ServiceType.vet,
+        'rating': 4.4,
+        'reviews': 34,
+        'dLat': -0.044,
+        'dLng': 0.028,
+        'phone': '+62 21 555-0707',
+        'slots': ['09:00', '11:30', '14:00'],
+      },
+    ];
+
+    return mockData.asMap().entries.map((entry) {
+      final i = entry.key;
+      final m = entry.value;
+
+      // Add tiny random jitter so markers don't overlap perfectly
+      final jitterLat = (rng.nextDouble() - 0.5) * 0.003;
+      final jitterLng = (rng.nextDouble() - 0.5) * 0.003;
+
+      // Calculate approximate distance
+      final lat = userLat + (m['dLat'] as double) + jitterLat;
+      final lng = userLng + (m['dLng'] as double) + jitterLng;
+      final dist = _haversineKm(userLat, userLng, lat, lng);
+
+      return NearbyService(
+        id: 'svc_$i',
+        name: m['name'] as String,
+        address: m['address'] as String,
+        type: m['type'] as ServiceType,
+        rating: m['rating'] as double,
+        reviewCount: m['reviews'] as int,
+        distanceKm: double.parse(dist.toStringAsFixed(1)),
+        position: LatLng(lat, lng),
+        phone: m['phone'] as String?,
+        availableSlots: List<String>.from(m['slots'] as List),
+      );
+    }).toList()
+      ..sort((a, b) => a.distanceKm.compareTo(b.distanceKm));
+  }
+
+  /// Simple Haversine formula to compute distance in km.
+  double _haversineKm(double lat1, double lng1, double lat2, double lng2) {
+    const r = 6371.0;
+    final dLat = _toRad(lat2 - lat1);
+    final dLng = _toRad(lng2 - lng1);
+    final a = sin(dLat / 2) * sin(dLat / 2) +
+        cos(_toRad(lat1)) * cos(_toRad(lat2)) * sin(dLng / 2) * sin(dLng / 2);
+    return r * 2 * atan2(sqrt(a), sqrt(1 - a));
+  }
+
+  double _toRad(double deg) => deg * pi / 180;
+}

--- a/mobile/purrcat_app_mobile/lib/data/services/firestore_service.dart
+++ b/mobile/purrcat_app_mobile/lib/data/services/firestore_service.dart
@@ -74,7 +74,6 @@ class FirestoreService {
         .orderBy('createdAt', descending: true)
         .snapshots()
         .map((snapshot) {
-      final currentUserId = _auth.currentUser?.uid;
       return snapshot.docs.map((doc) {
         final data = doc.data();
         // Also check the likes subcollection for the current user.

--- a/mobile/purrcat_app_mobile/lib/ui/features/feed/views/feed_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/feed/views/feed_screen.dart
@@ -2,8 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:dotted_border/dotted_border.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:go_router/go_router.dart';
-import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:async';
 
 import '../../../../data/models/feed_model.dart';
@@ -57,20 +55,6 @@ class _FeedScreenState extends State<FeedScreen> {
       completer.complete();
     });
     return completer.future;
-  }
-
-  void _onFabPressed() {
-    if (FirebaseAuth.instance.currentUser == null) {
-      showModalBottomSheet(
-        context: context,
-        isScrollControlled: true,
-        builder: (_) => LoginModal(
-          onLoginSuccess: () => context.push('/feed/create'),
-        ),
-      );
-    } else {
-      context.push('/feed/create');
-    }
   }
 
   @override

--- a/mobile/purrcat_app_mobile/lib/ui/features/marketplace/views/add_product_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/marketplace/views/add_product_screen.dart
@@ -313,7 +313,7 @@ class _AddProductScreenState extends State<AddProductScreen> {
 
   Widget _buildCategoryDropdown() {
     return DropdownButtonFormField<String>(
-      value: _category,
+      initialValue: _category,
       decoration: InputDecoration(
         hintText: 'Category',
         prefixIcon: const Icon(Icons.category, color: bodyColor, size: 20),
@@ -334,7 +334,7 @@ class _AddProductScreenState extends State<AddProductScreen> {
 
   Widget _buildStatusBadgeDropdown() {
     return DropdownButtonFormField<StatusBadge?>(
-      value: _statusBadge,
+      initialValue: _statusBadge,
       decoration: InputDecoration(
         hintText: 'Status Badge (optional)',
         prefixIcon: const Icon(Icons.verified, color: bodyColor, size: 20),

--- a/mobile/purrcat_app_mobile/lib/ui/features/marketplace/views/marketplace_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/marketplace/views/marketplace_screen.dart
@@ -309,7 +309,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                     'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=300',
                     width: 180,
                     fit: BoxFit.contain,
-                    errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    errorBuilder: (ctx, err, stack) => const SizedBox.shrink(),
                   ),
                 ),
               ),
@@ -324,7 +324,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
                       style: GoogleFonts.inter(
                         fontSize: 11,
                         fontWeight: FontWeight.w700,
-                        color: Colors.white.withOpacity(0.85),
+                        color: Colors.white.withValues(alpha: 0.85),
                         letterSpacing: 1.5,
                       ),
                     ),
@@ -377,7 +377,7 @@ class _MarketplaceScreenState extends State<MarketplaceScreen> {
           scrollDirection: Axis.horizontal,
           padding: const EdgeInsets.symmetric(horizontal: 16),
           itemCount: _categoryFilters.length,
-          separatorBuilder: (_, __) => const SizedBox(width: 8),
+          separatorBuilder: (_, i) => const SizedBox(width: 8),
           itemBuilder: (context, index) {
             final cat = _categoryFilters[index];
             final isSelected = _selectedCategory == cat.label;
@@ -488,7 +488,7 @@ class _ProductCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.06),
+            color: Colors.black.withValues(alpha: 0.06),
             blurRadius: 8,
             offset: const Offset(0, 3),
           ),
@@ -523,14 +523,14 @@ class _ProductCard extends StatelessWidget {
             CachedNetworkImage(
               imageUrl: item.imageUrl,
               fit: BoxFit.cover,
-              placeholder: (_, __) => Shimmer.fromColors(
+              placeholder: (c, i) => Shimmer.fromColors(
                 baseColor: Colors.grey.shade300,
                 highlightColor: Colors.grey.shade100,
                 child: Container(color: Colors.grey.shade300),
               ),
-              errorWidget: (_, __, ___) => Container(
+              errorWidget: (c, e, s) => Container(
                 color: Colors.grey.shade200,
-                child: Icon(Icons.pets, size: 32, color: brandPink.withOpacity(0.4)),
+                child: Icon(Icons.pets, size: 32, color: brandPink.withValues(alpha: 0.4)),
               ),
             ),
             // Report button — top left

--- a/mobile/purrcat_app_mobile/lib/ui/features/profile/views/profile_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/profile/views/profile_screen.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:firebase_auth/firebase_auth.dart' hide AuthProvider;
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
 

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/view_models/services_location_provider.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/view_models/services_location_provider.dart
@@ -1,0 +1,207 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../../../data/models/nearby_service_model.dart';
+import '../../../../data/repositories/nearby_services_repository.dart';
+
+// ── Fallback city centre (Jakarta) ───────────────────────────────────────────
+const LatLng kDefaultCenter = LatLng(-6.2000, 106.8166);
+
+/// All possible states of the location + data fetch pipeline.
+enum LocationStatus {
+  idle,              // Initial — nothing started yet
+  requesting,        // Waiting for OS permission dialog / GPS fix
+  granted,           // Real GPS position obtained  ← triggers map move
+  denied,            // User denied permission (can retry)
+  permanentlyDenied, // User denied forever → must open App Settings
+  serviceDisabled,   // Device GPS is switched off
+  gpuTimeout,        // GPS timed out (emulator with no mock location)
+  error,             // Unexpected error
+}
+
+/// Full state for the Services & Nearby screen.
+///
+/// Key design decisions:
+///   • [initialise()] is idempotent — safe to call multiple times.
+///   • Services are ONLY loaded AFTER a valid [userPosition] is confirmed.
+///   • [mapMoveCallback] is set by MapLayerState so the provider can push
+///     the camera to the real coordinates without a separate listener.
+///   • A [gpuTimeout] state is emitted when GPS times out so the screen
+///     can show a specific "GPS Timeout" dialog (distinct from generic error).
+class ServicesLocationProvider extends ChangeNotifier {
+  // ── Dependencies ──────────────────────────────────────────────────────────
+  final _repo = NearbyServicesRepository();
+
+  // ── State fields ──────────────────────────────────────────────────────────
+  LocationStatus _status = LocationStatus.idle;
+  LatLng _userPosition = kDefaultCenter; // starts at fallback
+  List<NearbyService> _nearbyServices = [];
+  NearbyService? _selectedService;
+  bool _loadingServices = false;
+  String? _errorMessage;
+
+  // ── Callback injected by MapLayerState ────────────────────────────────────
+  /// Set by MapLayerState.initState so we can push a MapController.move()
+  /// call the moment we have real coordinates — no polling needed.
+  void Function(LatLng position, double zoom)? mapMoveCallback;
+
+  // ── Getters ───────────────────────────────────────────────────────────────
+  LocationStatus get status => _status;
+  LatLng get userPosition => _userPosition;
+  List<NearbyService> get nearbyServices => _nearbyServices;
+  NearbyService? get selectedService => _selectedService;
+  bool get loadingServices => _loadingServices;
+  String? get errorMessage => _errorMessage;
+
+  bool get isLocating => _status == LocationStatus.requesting;
+  bool get hasRealLocation => _status == LocationStatus.granted;
+  bool get isGpsTimeout => _status == LocationStatus.gpuTimeout;
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  /// Entry point — call from initState (inside addPostFrameCallback).
+  /// Guards against duplicate calls via [_status] == idle check.
+  Future<void> initialise() async {
+    if (_status != LocationStatus.idle) return;
+    await _checkPermissionAndFetch();
+  }
+
+  /// Retry after denial, service-disabled, or timeout.
+  Future<void> retry() async {
+    _status = LocationStatus.idle;
+    _errorMessage = null;
+    _nearbyServices = [];
+    notifyListeners();
+    await _checkPermissionAndFetch();
+  }
+
+  /// Opens the native App Settings page (for permanently denied).
+  Future<void> openSettings() => Geolocator.openAppSettings();
+
+  /// Select / deselect a marker → drives the mini-card.
+  void selectService(NearbyService? service) {
+    _selectedService = service;
+    notifyListeners();
+  }
+
+  // ── Private — permission + GPS flow ──────────────────────────────────────
+
+  Future<void> _checkPermissionAndFetch() async {
+    _setStatus(LocationStatus.requesting);
+
+    // ── Step 1: Is the device GPS service enabled? ────────────────────────
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      _setStatus(
+        LocationStatus.serviceDisabled,
+        error: 'Location services are turned off. '
+            'Enable GPS in your device Settings, then tap Retry.',
+      );
+      // Load services at fallback so the map is not empty
+      await _loadServices(_userPosition);
+      return;
+    }
+
+    // ── Step 2: Check current permission level ────────────────────────────
+    LocationPermission permission = await Geolocator.checkPermission();
+
+    // ── Step 3: Show OS dialog if not yet decided ─────────────────────────
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    // ── Step 4: Permanently denied → guide to settings ───────────────────
+    if (permission == LocationPermission.deniedForever) {
+      _setStatus(
+        LocationStatus.permanentlyDenied,
+        error: 'Location permission is permanently blocked. '
+            'Open App Settings → Permissions → Location.',
+      );
+      await _loadServices(_userPosition);
+      return;
+    }
+
+    // ── Step 5: Still denied after dialog ─────────────────────────────────
+    if (permission == LocationPermission.denied) {
+      _setStatus(
+        LocationStatus.denied,
+        error: 'Location permission denied — showing city centre services.',
+      );
+      await _loadServices(_userPosition);
+      return;
+    }
+
+    // ── Step 6: Permission granted — fetch real GPS coordinates ──────────
+    //   We use a 20-second timeout so emulators with no mock location
+    //   produce a specific [gpuTimeout] state rather than hanging forever.
+    await _fetchPositionAndLoad();
+  }
+
+  Future<void> _fetchPositionAndLoad() async {
+    try {
+      final Position pos = await Geolocator.getCurrentPosition(
+        // AndroidSettings + AppleSettings give fine-grained control.
+        // For max emulator compatibility we also accept MEDIUM accuracy.
+        locationSettings: const LocationSettings(
+          accuracy: LocationAccuracy.high,
+          timeLimit: Duration(seconds: 20),
+        ),
+      );
+
+      // ✅ Real coordinates obtained
+      _userPosition = LatLng(pos.latitude, pos.longitude);
+      _setStatus(LocationStatus.granted); // notifyListeners() inside
+
+      // Push camera to user position immediately via the injected callback.
+      // This is the KEY fix: we call mapController.move() from the provider
+      // the instant we have coordinates, not on the next build() call.
+      mapMoveCallback?.call(_userPosition, 15.0);
+
+      // Load services centred on the REAL user position
+      await _loadServices(_userPosition);
+    } on TimeoutException {
+      // GPS timed out — specific state so the UI can show a targeted dialog
+      _setStatus(
+        LocationStatus.gpuTimeout,
+        error: 'GPS timed out. '
+            'Make sure Location is enabled and your emulator has '
+            'Mock Location configured (Extended Controls → Location).',
+      );
+      await _loadServices(_userPosition); // still show fallback markers
+    } catch (e) {
+      _setStatus(
+        LocationStatus.error,
+        error: 'Location error: ${e.toString()}. Showing city centre.',
+      );
+      await _loadServices(_userPosition);
+    }
+  }
+
+  // ── Private — data fetching ───────────────────────────────────────────────
+
+  /// Load nearby services for [pos]. Called ONLY after position is resolved.
+  Future<void> _loadServices(LatLng pos) async {
+    _loadingServices = true;
+    notifyListeners();
+    try {
+      _nearbyServices = await _repo.fetchNearbyServices(
+        userLat: pos.latitude,
+        userLng: pos.longitude,
+      );
+    } catch (_) {
+      _nearbyServices = [];
+    } finally {
+      _loadingServices = false;
+      notifyListeners();
+    }
+  }
+
+  void _setStatus(LocationStatus s, {String? error}) {
+    _status = s;
+    _errorMessage = error;
+    notifyListeners();
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/views/services_screen.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/views/services_screen.dart
@@ -1,79 +1,468 @@
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
+import 'package:provider/provider.dart';
+
 import '../../../../ui/core/theme.dart';
-import '../widgets/map_layer.dart';
-import '../widgets/services_header.dart';
+import '../view_models/services_location_provider.dart';
 import '../widgets/category_list.dart';
 import '../widgets/expert_list.dart';
+import '../widgets/map_layer.dart';
+import '../widgets/service_mini_card.dart';
+import '../widgets/services_header.dart';
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Services Screen — entry point
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Wraps the real screen with a scoped [ServicesLocationProvider] so the
+/// provider is created AND available before [_ServicesBody.initState] runs.
+///
+/// Split into two widgets to ensure Provider is in the tree before any
+/// context.read/watch calls happen in initState.
 class ServicesScreen extends StatelessWidget {
   const ServicesScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      backgroundColor: scaffoldBg,
-      body: Stack(
-        children: [
-          // ── Map Background (full height) ──
-          const Positioned.fill(child: MapLayer()),
+    return ChangeNotifierProvider<ServicesLocationProvider>(
+      create: (_) => ServicesLocationProvider(),
+      child: const _ServicesBody(),
+    );
+  }
+}
 
-          // ── Draggable Bottom Sheet ──
-          DraggableScrollableSheet(
-            initialChildSize: 0.6,
-            minChildSize: 0.3,
-            maxChildSize: 0.92,
-            builder: (context, scrollController) {
-              return Container(
-                decoration: const BoxDecoration(
-                  color: scaffoldBg,
-                  borderRadius: BorderRadius.only(
-                    topLeft: Radius.circular(24),
-                    topRight: Radius.circular(24),
-                  ),
-                  boxShadow: [
-                    BoxShadow(
-                      color: Colors.black12,
-                      blurRadius: 20,
-                      offset: Offset(0, -4),
-                    ),
-                  ],
-                ),
-                child: Column(
-                  children: [
-                    // ── Drag Handle ──
-                    const SizedBox(height: 8),
-                    Container(
-                      width: 40,
-                      height: 4,
-                      decoration: BoxDecoration(
-                        color: Colors.grey.shade300,
-                        borderRadius: BorderRadius.circular(2),
-                      ),
-                    ),
-                    const SizedBox(height: 4),
+// ─────────────────────────────────────────────────────────────────────────────
+// _ServicesBody — the actual screen that reads the provider
+// ─────────────────────────────────────────────────────────────────────────────
 
-                    // ── Scrollable Content ──
-                    Expanded(
-                      child: ListView(
-                        controller: scrollController,
-                        padding: const EdgeInsets.only(bottom: 100),
-                        children: const [
-                          ServicesHeader(),
-                          SizedBox(height: 12),
-                          CategoryList(),
-                          SizedBox(height: 16),
-                          ExpertList(),
-                          SizedBox(height: 24),
-                        ],
-                      ),
-                    ),
-                  ],
-                ),
-              );
+class _ServicesBody extends StatefulWidget {
+  const _ServicesBody();
+
+  @override
+  State<_ServicesBody> createState() => _ServicesBodyState();
+}
+
+class _ServicesBodyState extends State<_ServicesBody> {
+  final _mapKey = GlobalKey<MapLayerState>();
+
+  @override
+  void initState() {
+    super.initState();
+    // addPostFrameCallback guarantees the Provider tree and MapLayer are both
+    // mounted before we call initialise() — prevents "null mapController" race.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<ServicesLocationProvider>().initialise();
+    });
+  }
+
+  // ── GPS Timeout dialog ────────────────────────────────────────────────────
+  void _showGpsTimeoutDialog() {
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (dCtx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: const Row(
+          children: [
+            Icon(Icons.gps_off_rounded, color: Colors.orange),
+            SizedBox(width: 8),
+            Expanded(child: Text('GPS Timeout')),
+          ],
+        ),
+        content: const Text(
+          'Could not get a GPS fix within 20 seconds.\n\n'
+          'If you are on an emulator:\n'
+          '  1. Open Extended Controls (⋯ button)\n'
+          '  2. Go to Location tab\n'
+          '  3. Set coordinates and tap Send\n\n'
+          'Then tap Retry below.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dCtx),
+            child: const Text('Dismiss'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: brandPink,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            onPressed: () {
+              Navigator.pop(dCtx);
+              context.read<ServicesLocationProvider>().retry();
             },
+            child: const Text('Retry'),
           ),
         ],
+      ),
+    );
+  }
+
+  // ── Permanently denied dialog ─────────────────────────────────────────────
+  void _showPermanentlyDeniedDialog() {
+    showDialog<void>(
+      context: context,
+      builder: (dCtx) => AlertDialog(
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: const Row(
+          children: [
+            Icon(Icons.location_off_rounded, color: brandPink),
+            SizedBox(width: 8),
+            Expanded(child: Text('Location Required')),
+          ],
+        ),
+        content: const Text(
+          'Location permission is permanently denied.\n\n'
+          'Open App Settings → Permissions → Location\n'
+          'and set it to "Allow while using the app".',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(dCtx),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: brandPink,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
+            ),
+            onPressed: () {
+              Navigator.pop(dCtx);
+              context.read<ServicesLocationProvider>().openSettings();
+            },
+            child: const Text('Open Settings'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // ── Recenter FAB ──────────────────────────────────────────────────────────
+  void _recenter() {
+    final pos = context.read<ServicesLocationProvider>().userPosition;
+    _mapKey.currentState?.animateTo(pos);
+  }
+
+  // ── React to provider status changes for dialogs ─────────────────────────
+  // We use a listener pattern in build() instead of initState so we have
+  // context available when showing dialogs.
+  void _onStatusChanged(ServicesLocationProvider loc, LocationStatus prev) {
+    if (loc.status == LocationStatus.gpuTimeout && prev != LocationStatus.gpuTimeout) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _showGpsTimeoutDialog();
+      });
+    }
+    if (loc.status == LocationStatus.permanentlyDenied &&
+        prev != LocationStatus.permanentlyDenied) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _showPermanentlyDeniedDialog();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch status to fire dialogs when state transitions happen.
+    final loc = context.watch<ServicesLocationProvider>();
+
+    return Scaffold(
+      backgroundColor: scaffoldBg,
+      floatingActionButton: _RecenterFab(onTap: _recenter),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      body: _StatusListener(
+        onStatusChanged: _onStatusChanged,
+        child: Stack(
+          children: [
+            // ── 1. Full-screen map ──────────────────────────────────────
+            Positioned.fill(child: MapLayer(key: _mapKey)),
+
+            // ── 2. Top error / info banner ──────────────────────────────
+            _LocationBanner(
+              onOpenSettings: _showPermanentlyDeniedDialog,
+              onRetry: () =>
+                  context.read<ServicesLocationProvider>().retry(),
+            ),
+
+            // ── 3. Draggable bottom sheet ───────────────────────────────
+            _BottomSheet(isLoadingServices: loc.loadingServices),
+
+            // ── 4. Mini-card (marker tap) ───────────────────────────────
+            _MiniCardOverlay(selectedService: loc.selectedService),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Status listener — fires callbacks on status transitions
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _StatusListener extends StatefulWidget {
+  final Widget child;
+  final void Function(ServicesLocationProvider loc, LocationStatus prev)
+      onStatusChanged;
+
+  const _StatusListener({
+    required this.child,
+    required this.onStatusChanged,
+  });
+
+  @override
+  State<_StatusListener> createState() => _StatusListenerState();
+}
+
+class _StatusListenerState extends State<_StatusListener> {
+  LocationStatus _prev = LocationStatus.idle;
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = context.watch<ServicesLocationProvider>();
+    if (loc.status != _prev) {
+      final prev = _prev;
+      _prev = loc.status;
+      // Schedule the callback after this build frame completes.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onStatusChanged(loc, prev);
+      });
+    }
+    return widget.child;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Location error banner
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _LocationBanner extends StatelessWidget {
+  final VoidCallback onOpenSettings;
+  final VoidCallback onRetry;
+
+  const _LocationBanner({
+    required this.onOpenSettings,
+    required this.onRetry,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final status =
+        context.select<ServicesLocationProvider, LocationStatus>((l) => l.status);
+
+    final (show, message, isPermanent) = switch (status) {
+      LocationStatus.denied => (
+          true,
+          'Location denied — showing city centre',
+          false,
+        ),
+      LocationStatus.serviceDisabled => (
+          true,
+          'GPS is off — enable in device Settings',
+          false,
+        ),
+      LocationStatus.permanentlyDenied => (
+          true,
+          'Location blocked — tap to open Settings',
+          true,
+        ),
+      LocationStatus.gpuTimeout => (
+          true,
+          'GPS timeout — tap Retry or check emulator settings',
+          false,
+        ),
+      LocationStatus.error => (
+          true,
+          'Location error — showing city centre',
+          false,
+        ),
+      _ => (false, '', false),
+    };
+
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+      top: show ? MediaQuery.of(context).padding.top + 8 : -60,
+      left: 16,
+      right: 16,
+      child: show
+          ? GestureDetector(
+              onTap: isPermanent ? onOpenSettings : onRetry,
+              child: Container(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                decoration: BoxDecoration(
+                  color: const Color(0xFF1A1A1A).withValues(alpha: 0.88),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.location_off_rounded,
+                        color: Colors.white70, size: 18),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        message,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      isPermanent ? 'Fix' : 'Retry',
+                      style: const TextStyle(
+                        color: brandPink,
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Draggable bottom sheet
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _BottomSheet extends StatelessWidget {
+  final bool isLoadingServices;
+  const _BottomSheet({required this.isLoadingServices});
+
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+      initialChildSize: 0.42,
+      minChildSize: 0.18,
+      maxChildSize: 0.92,
+      builder: (ctx, scrollController) {
+        return Container(
+          decoration: const BoxDecoration(
+            color: scaffoldBg,
+            borderRadius: BorderRadius.vertical(top: Radius.circular(24)),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black12,
+                blurRadius: 20,
+                offset: Offset(0, -4),
+              ),
+            ],
+          ),
+          child: Column(
+            children: [
+              const SizedBox(height: 8),
+              Container(
+                width: 40,
+                height: 4,
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade300,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              const SizedBox(height: 4),
+              Expanded(
+                child: ListView(
+                  controller: scrollController,
+                  padding: const EdgeInsets.only(bottom: 100),
+                  children: [
+                    const ServicesHeader(),
+                    const SizedBox(height: 12),
+                    const CategoryList(),
+                    const SizedBox(height: 16),
+                    if (isLoadingServices)
+                      const Padding(
+                        padding: EdgeInsets.symmetric(vertical: 32),
+                        child: Center(
+                          child: Column(
+                            children: [
+                              CircularProgressIndicator(color: brandPink),
+                              SizedBox(height: 12),
+                              Text(
+                                'Finding nearby experts…',
+                                style: TextStyle(
+                                    fontSize: 13, color: bodyColor),
+                              ),
+                            ],
+                          ),
+                        ),
+                      )
+                    else
+                      const ExpertList(),
+                    const SizedBox(height: 24),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mini-card overlay (marker tap)
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _MiniCardOverlay extends StatelessWidget {
+  final dynamic selectedService;
+  const _MiniCardOverlay({this.selectedService});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedPositioned(
+      duration: const Duration(milliseconds: 280),
+      curve: Curves.easeOutCubic,
+      bottom: selectedService != null
+          ? MediaQuery.of(context).size.height * 0.42 + 8
+          : -120,
+      left: 0,
+      right: 0,
+      child: selectedService != null
+          ? ServiceMiniCard(
+              service: selectedService,
+              onClose: () =>
+                  context.read<ServicesLocationProvider>().selectService(null),
+            )
+          : const SizedBox.shrink(),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recenter FAB
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _RecenterFab extends StatelessWidget {
+  final VoidCallback onTap;
+  const _RecenterFab({required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).size.height * 0.42 + 12,
+      ),
+      child: FloatingActionButton.small(
+        onPressed: onTap,
+        backgroundColor: Colors.white,
+        elevation: 4,
+        tooltip: 'Recenter map',
+        child: const Icon(
+          Icons.my_location_rounded,
+          color: brandPink,
+          size: 22,
+        ),
       ),
     );
   }

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/category_list.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/category_list.dart
@@ -16,7 +16,7 @@ class CategoryList extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 20),
         scrollDirection: Axis.horizontal,
         itemCount: serviceCategories.length,
-        separatorBuilder: (_, __) => const SizedBox(width: 14),
+        separatorBuilder: (_, i) => const SizedBox(width: 14),
         itemBuilder: (context, index) {
           final cat = serviceCategories[index];
           return _CategoryCard(category: cat);
@@ -52,7 +52,7 @@ class _CategoryCard extends StatelessWidget {
                 width: 40,
                 height: 40,
                 decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.7),
+                  color: Colors.white.withValues(alpha: 0.7),
                   shape: BoxShape.circle,
                 ),
                 child: Icon(

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_card.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_card.dart
@@ -30,7 +30,7 @@ class _ExpertCardState extends State<ExpertCard> {
         borderRadius: BorderRadius.circular(16),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.04),
+            color: Colors.black.withValues(alpha: 0.04),
             blurRadius: 10,
             offset: const Offset(0, 2),
           ),
@@ -51,8 +51,8 @@ class _ExpertCardState extends State<ExpertCard> {
                         width: 56,
                         height: 56,
                         fit: BoxFit.cover,
-                        errorWidget: (_, __, ___) => _fallbackAvatar(),
-                        placeholder: (_, __) => Shimmer.fromColors(
+                        errorWidget: (ctx, err, stack) => _fallbackAvatar(),
+                        placeholder: (ctx, i) => Shimmer.fromColors(
                           baseColor: Colors.grey.shade200,
                           highlightColor: Colors.grey.shade100,
                           child: Container(
@@ -174,7 +174,7 @@ class _ExpertCardState extends State<ExpertCard> {
             child: ListView.separated(
               scrollDirection: Axis.horizontal,
               itemCount: expert.availableSlots.length,
-              separatorBuilder: (_, __) => const SizedBox(width: 8),
+              separatorBuilder: (_, i) => const SizedBox(width: 8),
               itemBuilder: (context, index) {
                 final slot = expert.availableSlots[index];
                 final isSelected = _selectedSlot == slot;
@@ -222,7 +222,7 @@ class _ExpertCardState extends State<ExpertCard> {
       width: 56,
       height: 56,
       decoration: BoxDecoration(
-        color: brandPink.withOpacity(0.12),
+        color: brandPink.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(15),
       ),
       child: const Icon(Icons.person, color: brandPink, size: 28),

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_list.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/expert_list.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import '../../../../data/models/services_model.dart';
 import '../../../../data/services/mock_services_data.dart';
 import 'expert_card.dart';
 

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/map_layer.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/map_layer.dart
@@ -1,107 +1,330 @@
+import 'dart:ui' as ui;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import '../../../../ui/core/theme.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:provider/provider.dart';
 
-class MapLayer extends StatelessWidget {
+import '../../../../data/models/nearby_service_model.dart';
+import '../../../../ui/core/theme.dart';
+import '../view_models/services_location_provider.dart';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MapLayer — full-screen interactive map
+// ─────────────────────────────────────────────────────────────────────────────
+
+class MapLayer extends StatefulWidget {
   const MapLayer({super.key});
 
   @override
+  State<MapLayer> createState() => MapLayerState();
+}
+
+class MapLayerState extends State<MapLayer> with TickerProviderStateMixin {
+  final MapController mapController = MapController();
+
+  late AnimationController _pulseCtrl;
+  late Animation<double> _pulseAnim;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // ── Pulsing animation for the blue user-dot ───────────────────────────
+    _pulseCtrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat(reverse: true);
+    _pulseAnim = Tween<double>(begin: 0.5, end: 1.0).animate(
+      CurvedAnimation(parent: _pulseCtrl, curve: Curves.easeInOut),
+    );
+
+    // ── KEY FIX: Register the map-move callback on the provider ──────────
+    // When the provider gets a real GPS fix it calls this function directly
+    // instead of relying on the next build() cycle — this guarantees the
+    // camera snaps to the user's position even before a repaint is triggered.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      context.read<ServicesLocationProvider>().mapMoveCallback =
+          (LatLng pos, double zoom) {
+        if (!mounted) return;
+        // Use MapController.move() for an instant snap (no animation).
+        // The recenter FAB uses animateTo() for the smooth fly-in.
+        mapController.move(pos, zoom);
+      };
+    });
+  }
+
+  @override
+  void dispose() {
+    // Clear the callback so the provider doesn't call into a dead widget.
+    if (mounted) {
+      try {
+        context.read<ServicesLocationProvider>().mapMoveCallback = null;
+      } catch (_) {}
+    }
+    _pulseCtrl.dispose();
+    super.dispose();
+  }
+
+  // ── Public: smooth animated fly-to (used by the recenter FAB) ────────────
+  void animateTo(LatLng target, {double zoom = 15}) {
+    final begin = mapController.camera.center;
+    final ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 700),
+    );
+    final latAnim =
+        Tween<double>(begin: begin.latitude, end: target.latitude).animate(
+      CurvedAnimation(parent: ctrl, curve: Curves.easeInOut),
+    );
+    final lngAnim =
+        Tween<double>(begin: begin.longitude, end: target.longitude).animate(
+      CurvedAnimation(parent: ctrl, curve: Curves.easeInOut),
+    );
+    final zoomAnim =
+        Tween<double>(begin: mapController.camera.zoom, end: zoom).animate(
+      CurvedAnimation(parent: ctrl, curve: Curves.easeInOut),
+    );
+
+    ctrl.addListener(() {
+      mapController.move(
+        LatLng(latAnim.value, lngAnim.value),
+        zoomAnim.value,
+      );
+    });
+    ctrl.addStatusListener((s) {
+      if (s == AnimationStatus.completed || s == AnimationStatus.dismissed) {
+        ctrl.dispose();
+      }
+    });
+    ctrl.forward();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final loc = context.watch<ServicesLocationProvider>();
+
     return Stack(
       children: [
-        // ── Placeholder Map ──
-        Container(
-          color: const Color(0xFFE8F0FE),
-          child: const Center(
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                Icon(Icons.map_outlined, size: 48, color: Color(0xFFB0BEC5)),
-                SizedBox(height: 8),
-                Text(
-                  'Map View\n(Google Maps / Mapbox)',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    color: Color(0xFF90A4AE),
-                    fontSize: 14,
-                    fontWeight: FontWeight.w500,
-                  ),
-                ),
-              ],
+        // ── FlutterMap ────────────────────────────────────────────────────
+        FlutterMap(
+          mapController: mapController,
+          options: MapOptions(
+            // Always start at kDefaultCenter; the mapMoveCallback snaps it
+            // to the real position once GPS resolves.
+            initialCenter: kDefaultCenter,
+            initialZoom: 13,
+            minZoom: 10,
+            maxZoom: 18,
+            interactionOptions: const InteractionOptions(
+              flags: InteractiveFlag.all & ~InteractiveFlag.rotate,
             ),
+            onTap: (pos, point) => loc.selectService(null),
           ),
-        ),
+          children: [
+            // ── OSM tile layer (zero-cost, no API key) ────────────────────
+            TileLayer(
+              urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+              userAgentPackageName: 'com.purrcat.app',
+              maxNativeZoom: 19,
+            ),
 
-        // ── Custom Marker: Paws Clinic ──
-        Positioned(
-          left: 60,
-          top: 40,
-          child: _CustomMarker(
-            label: 'PAWS',
-            subLabel: 'CLINIC',
-            icon: Icons.medical_services,
-            color: const Color(0xFF8B1A4A), // Dark Pink/Maroon
-          ),
-        ),
+            // ── Nearby service markers ─────────────────────────────────────
+            MarkerLayer(
+              markers: loc.nearbyServices
+                  .map<Marker>((svc) => _buildServiceMarker(svc, loc))
+                  .toList(),
+            ),
 
-        // ── Custom Marker: Fluff & Buff ──
-        Positioned(
-          right: 100,
-          bottom: 80,
-          child: _CustomMarker(
-            label: 'FLUFF',
-            subLabel: '& BUFF',
-            icon: Icons.content_cut,
-            color: brandPink,
-          ),
-        ),
-
-        // ── My Location FAB ──
-        Positioned(
-          right: 16,
-          bottom: 16,
-          child: GestureDetector(
-            onTap: () {
-              HapticFeedback.lightImpact();
-            },
-            child: Container(
-              width: 40,
-              height: 40,
-              decoration: BoxDecoration(
-                color: Colors.white,
-                shape: BoxShape.circle,
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black.withOpacity(0.15),
-                    blurRadius: 6,
-                    offset: const Offset(0, 2),
+            // ── User blue dot — only shown when we have real GPS ──────────
+            if (loc.hasRealLocation)
+              MarkerLayer(
+                markers: [
+                  Marker(
+                    point: loc.userPosition,
+                    width: 60,
+                    height: 60,
+                    child: _UserDot(pulseAnim: _pulseAnim),
                   ),
                 ],
               ),
-              child: const Icon(
-                Icons.my_location,
-                color: brandPink,
-                size: 20,
-              ),
+
+            // ── OSM attribution (required by tile policy) ─────────────────
+            const RichAttributionWidget(
+              attributions: [
+                TextSourceAttribution('OpenStreetMap contributors'),
+              ],
             ),
+          ],
+        ),
+
+        // ── Full-screen GPS loading overlay ───────────────────────────────
+        // Shown while we're waiting for the permission dialog / GPS fix.
+        // This prevents the user seeing a blank Jakarta map before GPS resolves.
+        if (loc.isLocating) const _GpsLoadingOverlay(),
+      ],
+    );
+  }
+
+  Marker _buildServiceMarker(NearbyService svc, ServicesLocationProvider loc) {
+    final isSelected = loc.selectedService?.id == svc.id;
+    final color =
+        svc.type == ServiceType.vet ? const Color(0xFF8B1A4A) : brandPink;
+    final icon = svc.type == ServiceType.vet
+        ? Icons.medical_services_rounded
+        : Icons.content_cut_rounded;
+
+    return Marker(
+      point: svc.position,
+      width: 120,
+      height: 90,
+      child: GestureDetector(
+        onTap: () {
+          HapticFeedback.selectionClick();
+          loc.selectService(isSelected ? null : svc);
+        },
+        child: AnimatedScale(
+          scale: isSelected ? 1.15 : 1.0,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOutBack,
+          child: _ServiceMarker(
+            label: svc.name,
+            icon: icon,
+            color: color,
+            isSelected: isSelected,
           ),
         ),
-      ],
+      ),
     );
   }
 }
 
-class _CustomMarker extends StatelessWidget {
+// ─────────────────────────────────────────────────────────────────────────────
+// GPS Loading Overlay
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Semi-transparent full-screen overlay shown while the GPS fix is pending.
+/// Prevents the user seeing the Jakarta default map before their position loads.
+class _GpsLoadingOverlay extends StatelessWidget {
+  const _GpsLoadingOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black.withValues(alpha: 0.45),
+      child: Center(
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(20),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withValues(alpha: 0.15),
+                blurRadius: 24,
+              ),
+            ],
+          ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const SizedBox(
+                width: 40,
+                height: 40,
+                child: CircularProgressIndicator(
+                  strokeWidth: 3,
+                  color: brandPink,
+                ),
+              ),
+              const SizedBox(height: 16),
+              const Text(
+                'Finding your location…',
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w700,
+                  color: headingColor,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                'Waiting for GPS signal',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: bodyColor.withValues(alpha: 0.8),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// User position blue dot
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _UserDot extends StatelessWidget {
+  final Animation<double> pulseAnim;
+  const _UserDot({required this.pulseAnim});
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: pulseAnim,
+      builder: (ctx, child) => Center(
+        child: Stack(
+          alignment: Alignment.center,
+          children: [
+            Container(
+              width: 36 * pulseAnim.value,
+              height: 36 * pulseAnim.value,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: const Color(0xFF4285F4).withValues(alpha: 0.25),
+              ),
+            ),
+            Container(
+              width: 20,
+              height: 20,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Colors.white,
+              ),
+            ),
+            Container(
+              width: 14,
+              height: 14,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Color(0xFF4285F4),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Service pin marker
+// ─────────────────────────────────────────────────────────────────────────────
+
+class _ServiceMarker extends StatelessWidget {
   final String label;
-  final String subLabel;
   final IconData icon;
   final Color color;
+  final bool isSelected;
 
-  const _CustomMarker({
+  const _ServiceMarker({
     required this.label,
-    required this.subLabel,
     required this.icon,
     required this.color,
+    required this.isSelected,
   });
 
   @override
@@ -109,49 +332,77 @@ class _CustomMarker extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        // Pin icon
-        Container(
-          width: 44,
-          height: 44,
-          decoration: BoxDecoration(
-            color: color,
-            shape: BoxShape.circle,
-            border: Border.all(color: Colors.white, width: 2),
-            boxShadow: [
-              BoxShadow(
-                color: color.withOpacity(0.4),
-                blurRadius: 8,
-                offset: const Offset(0, 2),
-              ),
-            ],
-          ),
-          child: Icon(icon, color: Colors.white, size: 22),
-        ),
-        const SizedBox(height: 4),
-        // Label
-        Column(
-          children: [
-            Text(
-              label,
-              style: const TextStyle(
-                fontSize: 10,
-                fontWeight: FontWeight.w700,
-                color: Colors.black87,
-                letterSpacing: 0.5,
-              ),
+        AnimatedOpacity(
+          opacity: isSelected ? 1.0 : 0.85,
+          duration: const Duration(milliseconds: 200),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: isSelected ? color : Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withValues(alpha: 0.18),
+                  blurRadius: 6,
+                  offset: const Offset(0, 2),
+                ),
+              ],
             ),
-            Text(
-              subLabel,
-              style: const TextStyle(
+            child: Text(
+              label,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
                 fontSize: 9,
-                fontWeight: FontWeight.w600,
-                color: Colors.black87,
+                fontWeight: FontWeight.w700,
+                color: isSelected ? Colors.white : color,
                 letterSpacing: 0.3,
               ),
             ),
-          ],
+          ),
+        ),
+        const SizedBox(height: 2),
+        Container(
+          width: 36,
+          height: 36,
+          decoration: BoxDecoration(
+            color: color,
+            shape: BoxShape.circle,
+            border: Border.all(color: Colors.white, width: isSelected ? 2.5 : 2),
+            boxShadow: [
+              BoxShadow(
+                color: color.withValues(alpha: 0.45),
+                blurRadius: isSelected ? 12 : 8,
+                offset: const Offset(0, 3),
+              ),
+            ],
+          ),
+          child: Icon(icon, color: Colors.white, size: 18),
+        ),
+        CustomPaint(
+          size: const Size(10, 6),
+          painter: _PinTailPainter(color: color),
         ),
       ],
     );
   }
+}
+
+class _PinTailPainter extends CustomPainter {
+  final Color color;
+  const _PinTailPainter({required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()..color = color;
+    final path = ui.Path()
+      ..moveTo(0, 0)
+      ..lineTo(size.width, 0)
+      ..lineTo(size.width / 2, size.height)
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _PinTailPainter old) => old.color != color;
 }

--- a/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/service_mini_card.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/features/services/widgets/service_mini_card.dart
@@ -1,0 +1,131 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../../../data/models/nearby_service_model.dart';
+import '../../../../ui/core/theme.dart';
+
+/// Floating mini-card that slides up when a map marker is tapped.
+class ServiceMiniCard extends StatelessWidget {
+  final NearbyService service;
+  final VoidCallback onClose;
+
+  const ServiceMiniCard({
+    super.key,
+    required this.service,
+    required this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = service.type == ServiceType.vet
+        ? const Color(0xFF8B1A4A)
+        : brandPink;
+    final icon = service.type == ServiceType.vet
+        ? Icons.medical_services_rounded
+        : Icons.content_cut_rounded;
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.12),
+            blurRadius: 20,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: Row(
+        children: [
+          // ── Icon badge ────────────────────────────────────────────────
+          Container(
+            width: 48,
+            height: 48,
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(14),
+            ),
+            child: Icon(icon, color: color, size: 24),
+          ),
+          const SizedBox(width: 12),
+
+          // ── Info ──────────────────────────────────────────────────────
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  service.name,
+                  style: GoogleFonts.inter(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: headingColor,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  service.typeLabel,
+                  style: GoogleFonts.inter(
+                    fontSize: 11,
+                    color: color,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Row(
+                  children: [
+                    const Icon(Icons.star_rounded,
+                        size: 13, color: Color(0xFFFFB800)),
+                    const SizedBox(width: 3),
+                    Text(
+                      service.rating.toStringAsFixed(1),
+                      style: GoogleFonts.inter(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          color: headingColor),
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      '(${service.reviewCount})',
+                      style: GoogleFonts.inter(
+                          fontSize: 11, color: bodyColor),
+                    ),
+                    const Spacer(),
+                    Icon(Icons.near_me_rounded,
+                        size: 12, color: bodyColor),
+                    const SizedBox(width: 3),
+                    Text(
+                      '${service.distanceKm} km',
+                      style: GoogleFonts.inter(
+                          fontSize: 11, color: bodyColor),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+
+          // ── Close ─────────────────────────────────────────────────────
+          GestureDetector(
+            onTap: onClose,
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: BoxDecoration(
+                color: Colors.grey.shade100,
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.close, size: 16, color: bodyColor),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/mobile/purrcat_app_mobile/lib/ui/shared/bottom_nav_component.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/bottom_nav_component.dart
@@ -19,7 +19,7 @@ class BottomNavComponent extends StatelessWidget {
         color: backgroundColor,
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.08),
+            color: Colors.black.withValues(alpha: 0.08),
             blurRadius: 12,
             offset: const Offset(0, -2),
           ),
@@ -51,7 +51,7 @@ class BottomNavComponent extends StatelessWidget {
         duration: const Duration(milliseconds: 200),
         padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
         decoration: BoxDecoration(
-          color: isActive ? brandPink.withOpacity(0.12) : Colors.transparent,
+          color: isActive ? brandPink.withValues(alpha: 0.12) : Colors.transparent,
           borderRadius: BorderRadius.circular(12),
         ),
         child: Column(

--- a/mobile/purrcat_app_mobile/lib/ui/shared/feed_header.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/feed_header.dart
@@ -10,7 +10,7 @@ class FeedHeader extends StatelessWidget implements PreferredSizeWidget {
   @override
   final Size preferredSize;
 
-  FeedHeader({
+  const FeedHeader({
     super.key,
     required this.title,
     this.leading,
@@ -34,7 +34,7 @@ class FeedHeader extends StatelessWidget implements PreferredSizeWidget {
               style: const TextStyle(
                 fontSize: 22,
                 fontWeight: FontWeight.bold,
-brandPink
+                color: brandPink,
               ),
             ),
           ),

--- a/mobile/purrcat_app_mobile/lib/ui/shared/report_modal.dart
+++ b/mobile/purrcat_app_mobile/lib/ui/shared/report_modal.dart
@@ -166,7 +166,7 @@ class _ReportModalState extends State<ReportModal> {
                       const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
                   decoration: BoxDecoration(
                     color: isSelected
-                        ? brandPink.withOpacity(0.1)
+                        ? brandPink.withValues(alpha: 0.1)
                         : Colors.grey.shade50,
                     borderRadius: BorderRadius.circular(12),
                     border: Border.all(

--- a/mobile/purrcat_app_mobile/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/mobile/purrcat_app_mobile/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -10,7 +10,9 @@ import file_selector_macos
 import firebase_auth
 import firebase_core
 import firebase_storage
+import geolocator_apple
 import google_sign_in_ios
+import package_info_plus
 import shared_preferences_foundation
 import sqflite_darwin
 
@@ -20,7 +22,9 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseAuthPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseAuthPlugin"))
   FLTFirebaseCorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCorePlugin"))
   FLTFirebaseStoragePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseStoragePlugin"))
+  GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
 }

--- a/mobile/purrcat_app_mobile/pubspec.lock
+++ b/mobile/purrcat_app_mobile/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.59"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: transitive
     description:
@@ -137,6 +145,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  dart_earcut:
+    dependency: transitive
+    description:
+      name: dart_earcut
+      sha256: e485001bfc05dcbc437d7bfb666316182e3522d4c3f9668048e004d0eb2ce43b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.0"
+  dart_polylabel2:
+    dependency: transitive
+    description:
+      name: dart_polylabel2
+      sha256: "7eeab15ce72894e4bdba6a8765712231fc81be0bd95247de4ad9966abc57adc6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  dbus:
+    dependency: transitive
+    description:
+      name: dbus
+      sha256: d0c98dcd4f5169878b6cf8f6e0a52403a9dff371a3e2f019697accbf6f44a270
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.12"
   dio:
     dependency: "direct main"
     description:
@@ -318,6 +350,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_map:
+    dependency: "direct main"
+    description:
+      name: flutter_map
+      sha256: "03b71c02806ff20c3718d108cbbb3638142ebafe368d8ce2dd22a33344bcb02b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.3.0"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -336,6 +376,70 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  geoclue:
+    dependency: transitive
+    description:
+      name: geoclue
+      sha256: c2a998c77474fc57aa00c6baa2928e58f4b267649057a1c76738656e9dbd2a7f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  geolocator:
+    dependency: "direct main"
+    description:
+      name: geolocator
+      sha256: "79939537046c9025be47ec645f35c8090ecadb6fe98eba146a0d25e8c1357516"
+      url: "https://pub.dev"
+    source: hosted
+    version: "14.0.2"
+  geolocator_android:
+    dependency: transitive
+    description:
+      name: geolocator_android
+      sha256: "179c3cb66dfa674fc9ccbf2be872a02658724d1c067634e2c427cf6df7df901a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
+  geolocator_apple:
+    dependency: transitive
+    description:
+      name: geolocator_apple
+      sha256: dbdd8789d5aaf14cf69f74d4925ad1336b4433a6efdf2fce91e8955dc921bf22
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.13"
+  geolocator_linux:
+    dependency: transitive
+    description:
+      name: geolocator_linux
+      sha256: d64112a205931926f4363bb6bd48f14cb38e7326833041d170615586cd143797
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
+  geolocator_platform_interface:
+    dependency: transitive
+    description:
+      name: geolocator_platform_interface
+      sha256: "30cb64f0b9adcc0fb36f628b4ebf4f731a2961a0ebd849f4b56200205056fe67"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.6"
+  geolocator_web:
+    dependency: transitive
+    description:
+      name: geolocator_web
+      sha256: b1ae9bdfd90f861fde8fd4f209c37b953d65e92823cb73c7dee1fa021b06f172
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.3"
+  geolocator_windows:
+    dependency: transitive
+    description:
+      name: geolocator_windows
+      sha256: "175435404d20278ffd220de83c2ca293b73db95eafbdc8131fe8609be1421eb6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.5"
   glob:
     dependency: transitive
     description:
@@ -408,6 +512,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.12.4+4"
+  gsettings:
+    dependency: transitive
+    description:
+      name: gsettings
+      sha256: "1b0ce661f5436d2db1e51f3c4295a49849f03d304003a7ba177d01e3a858249c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   hooks:
     dependency: transitive
     description:
@@ -520,6 +632,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  latlong2:
+    dependency: "direct main"
+    description:
+      name: latlong2
+      sha256: "98227922caf49e6056f91b6c56945ea1c7b166f28ffcd5fb8e72fc0b453cc8fe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -584,6 +704,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  mgrs_dart:
+    dependency: transitive
+    description:
+      name: mgrs_dart
+      sha256: "385e7168ecc77eb545220223c49eef8ab249da7bf57f22781c40a04d23fb196f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   mime:
     dependency: transitive
     description:
@@ -632,6 +760,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -704,6 +848,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   platform:
     dependency: transitive
     description:
@@ -720,6 +872,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  proj4dart:
+    dependency: transitive
+    description:
+      name: proj4dart
+      sha256: ddcedc1f7876e62717de43ab3491e2829bdad0b028261805f94aa080967e5859
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   provider:
     dependency: "direct main"
     description:
@@ -816,6 +984,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  simple_sparse_list:
+    dependency: transitive
+    description:
+      name: simple_sparse_list
+      sha256: aa648fd240fa39b49dcd11c19c266990006006de6699a412de485695910fbc1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -925,6 +1101,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unicode:
+    dependency: transitive
+    description:
+      name: unicode
+      sha256: a6f7bcfc8ea1d5ce1f6c0b1c39117a9919f4953edd9fd7a64090a9796c499b57
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9"
   uuid:
     dependency: transitive
     description:
@@ -957,6 +1141,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      sha256: d7cb55e04cd34096cd3a79b3330245f54cb96a370a1c27adb3c84b917de8b08e
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.15.0"
+  wkt_parser:
+    dependency: transitive
+    description:
+      name: wkt_parser
+      sha256: "8a555fc60de3116c00aad67891bcab20f81a958e4219cc106e3c037aa3937f13"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   xdg_directories:
     dependency: transitive
     description:
@@ -965,6 +1165,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
   yaml:
     dependency: transitive
     description:

--- a/mobile/purrcat_app_mobile/pubspec.yaml
+++ b/mobile/purrcat_app_mobile/pubspec.yaml
@@ -62,6 +62,9 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   image_picker: ^1.2.2
+  flutter_map: ^8.3.0
+  latlong2: ^0.9.1
+  geolocator: ^14.0.2
 
 dev_dependencies:
   flutter_test:

--- a/mobile/purrcat_app_mobile/windows/flutter/generated_plugin_registrant.cc
+++ b/mobile/purrcat_app_mobile/windows/flutter/generated_plugin_registrant.cc
@@ -11,6 +11,7 @@
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
 #include <firebase_storage/firebase_storage_plugin_c_api.h>
+#include <geolocator_windows/geolocator_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -23,4 +24,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
   FirebaseStoragePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseStoragePluginCApi"));
+  GeolocatorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("GeolocatorWindows"));
 }

--- a/mobile/purrcat_app_mobile/windows/flutter/generated_plugins.cmake
+++ b/mobile/purrcat_app_mobile/windows/flutter/generated_plugins.cmake
@@ -8,6 +8,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   firebase_auth
   firebase_core
   firebase_storage
+  geolocator_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
## Overview
Replaces the static map placeholder with a fully functional, **zero-cost** map using `flutter_map` + OpenStreetMap tiles. Implements real-time GPS location, a complete permission workflow, and a mock "Nearby Services" data layer.

---

## What Changed

### New Files
| File | Purpose |
|---|---|
| `data/models/nearby_service_model.dart` | `NearbyService` model with `LatLng`, `ServiceType` enum |
| `data/repositories/nearby_services_repository.dart` | Mock `GET /v1/services/nearby` using Haversine distance |
| `ui/.../view_models/services_location_provider.dart` | Full GPS + permission state machine (ChangeNotifier) |
| `ui/.../widgets/service_mini_card.dart` | Floating card shown on marker tap |

### Modified Files
| File | Change |
|---|---|
| `AndroidManifest.xml` | Added `ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION`, `INTERNET` |
| `ios/Runner/Info.plist` | Added `NSLocationWhenInUseUsageDescription` (was missing — caused silent iOS denial) |
| `widgets/map_layer.dart` | OSM tiles, animated blue-dot, custom service markers, GPS loading overlay |
| `views/services_screen.dart` | Provider scoping fix, GPS Timeout dialog, recenter FAB, mini-card overlay |

---

## Architecture

### Root-Cause Fix: Camera Never Moved
The old code set `initialCenter` at widget creation (Jakarta fallback) and never called `mapController.move()` when GPS resolved.

**Fix:** `MapLayerState.initState()` registers a `mapMoveCallback` directly on the provider. The instant GPS resolves, the provider calls `mapMoveCallback(realLatLng, 15.0)` which directly invokes `mapController.move()` — no build-cycle polling needed.

### Provider Scoping Fix
`ServicesScreen` previously created the `ChangeNotifierProvider` inside its own `build()` then tried to `context.read()` it in `initState` — the context was an ancestor of the provider, causing `ProviderNotFoundException` on every startup.

**Fix:** `ServicesScreen` (StatelessWidget, creates provider) wraps `_ServicesBody` (StatefulWidget, reads provider). Provider is guaranteed in the tree before `initState` runs.

---

## Permission Flow

```
initState → initialise()
  ├─ GPS service off?     → serviceDisabled banner + fallback markers
  ├─ Permission denied    → OS dialog shown
  │    ├─ Still denied    → denied banner + Retry + fallback markers
  │    └─ Denied forever  → permanentlyDenied dialog → Open Settings
  ├─ GPS timeout (>20s)   → gpuTimeout dialog with emulator instructions
  └─ Granted              → getCurrentPosition() → mapMoveCallback()
                                └─ fetchNearbyServices(lat, lng) → markers
```

---

## Testing on Emulator
If GPS times out: **⋯ (Extended Controls) → Location → set Lat/Lng → Send**

---

## Checklist
- [x] `flutter analyze` → 0 issues
- [x] `flutter build apk --debug` → ✓ Built
- [x] Android permissions configured
- [x] iOS Info.plist keys added
- [x] Provider scoping verified
